### PR TITLE
Handle option terminator in shout CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # thing-python
 Think Python: How to Think Like a Computer Scientist
+
+## Greeting script
+
+```
+$ node index.js Alice
+Hello, Alice!
+
+$ node index.js Alice --shout
+HELLO, ALICE!
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const args = process.argv.slice(2);
+let shouldShout = false;
+let parsingOptions = true;
+const names = [];
+
+for (const arg of args) {
+  if (parsingOptions && arg === '--') {
+    parsingOptions = false;
+    continue;
+  }
+
+  if (parsingOptions && arg === '--shout') {
+    shouldShout = true;
+    continue;
+  }
+
+  names.push(arg);
+}
+
+const name = names[0] || 'World';
+let greeting = `Hello, ${name}!`;
+
+if (shouldShout) {
+  greeting = greeting.toUpperCase();
+}
+
+console.log(greeting);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "thing-python",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { promisify } = require('node:util');
+const { execFile } = require('node:child_process');
+
+const execFileAsync = promisify(execFile);
+
+async function runCli(args) {
+  const { stdout } = await execFileAsync(process.execPath, ['index.js', ...args]);
+  return stdout.trim();
+}
+
+test('greets with the provided name', async () => {
+  const output = await runCli(['Alice']);
+  assert.strictEqual(output, 'Hello, Alice!');
+});
+
+test('uppercases the greeting when --shout is provided', async () => {
+  const output = await runCli(['Alice', '--shout']);
+  assert.strictEqual(output, 'HELLO, ALICE!');
+});
+
+test('treats --shout as a name after --', async () => {
+  const output = await runCli(['--', '--shout']);
+  assert.strictEqual(output, 'Hello, --shout!');
+});


### PR DESCRIPTION
## Summary
- stop parsing options after `--` so literal values like `--shout` can still be greeted
- add coverage to confirm the CLI still treats `--shout` as a name when escaped

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c930ef0a48832091654dc9cad25871