### PR TITLE
Add EPUB chapter conversion utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # thing-python
+
 Think Python: How to Think Like a Computer Scientist
+
+## Book conversion helpers
+
+This repository now includes a small utility for extracting the textual content
+of an EPUB book into individual chapter files.  The tool lives in
+`scripts/convert_book.py` and wraps the logic provided by
+`book_tools.converter`.
+
+```bash
+# convert a specific file
+python scripts/convert_book.py path/to/book.epub --output converted_chapters
+
+# or place a single EPUB inside ./book or ./data and run without arguments
+python scripts/convert_book.py
+```
+
+The converter will create one UTF-8 encoded `.txt` file per chapter in the
+output directory.

--- a/book_tools/__init__.py
+++ b/book_tools/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for converting book formats into plain text chapters."""
+
+from .converter import convert_book, convert_epub_to_text
+
+__all__ = ["convert_book", "convert_epub_to_text"]

--- a/book_tools/converter.py
+++ b/book_tools/converter.py
@@ -1,0 +1,256 @@
+"""Book conversion helpers for extracting plain text chapters."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import unescape
+from html.parser import HTMLParser
+import os
+import posixpath
+import re
+from typing import Iterable, Iterator, List, Optional, Sequence
+import unicodedata
+import zipfile
+import xml.etree.ElementTree as ET
+
+
+# EPUB XML namespaces used within the OPF file.  The namespace mapping is kept
+# in a dedicated constant to avoid repeating the URIs throughout the code.
+OPF_NS = {
+    "container": "urn:oasis:names:tc:opendocument:xmlns:container",
+    "opf": "http://www.idpf.org/2007/opf",
+}
+
+
+@dataclass
+class Chapter:
+    """Representation of an extracted chapter."""
+
+    index: int
+    title: str
+    text: str
+
+
+class _HTMLToTextParser(HTMLParser):
+    """A small HTML to plain text converter.
+
+    EPUB chapters typically arrive as XHTML documents.  A fully fledged HTML
+    renderer would be excessive, so we implement a light-weight parser that
+    keeps track of block elements and headings in order to produce readable
+    plain text output.  The parser also remembers the first heading encountered
+    which is generally the chapter title.
+    """
+
+    _BLOCK_TAGS = {
+        "address",
+        "article",
+        "aside",
+        "blockquote",
+        "br",
+        "div",
+        "dl",
+        "dt",
+        "dd",
+        "figcaption",
+        "figure",
+        "footer",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "li",
+        "main",
+        "nav",
+        "ol",
+        "p",
+        "pre",
+        "section",
+        "table",
+        "tr",
+        "ul",
+    }
+
+    _TITLE_TAGS = {"h1", "h2", "title"}
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._parts: List[str] = []
+        self._pending_space = False
+        self._title: Optional[str] = None
+        self._capture_title = False
+
+    @property
+    def title(self) -> Optional[str]:
+        return self._title
+
+    def handle_starttag(self, tag: str, attrs: Sequence[tuple[str, str]]) -> None:
+        tag = tag.lower()
+        if tag in self._BLOCK_TAGS:
+            self._ensure_newline()
+        if tag in self._TITLE_TAGS:
+            self._capture_title = True
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in self._BLOCK_TAGS:
+            self._ensure_newline()
+        if tag in self._TITLE_TAGS:
+            self._capture_title = False
+
+    def handle_data(self, data: str) -> None:
+        if not data.strip():
+            self._pending_space = True
+            return
+
+        text = unescape(data)
+        content = text.strip()
+        if not content:
+            return
+
+        if self._pending_space and self._parts:
+            if content[0] not in '.,;:!?)]}»”’':
+                self._parts.append(" ")
+        self._parts.append(content)
+        self._pending_space = True
+
+        if self._capture_title and content:
+            if not self._title:
+                self._title = content
+
+    def get_text(self) -> str:
+        raw = "".join(self._parts)
+        # Replace multiple blank lines with two and strip trailing whitespace.
+        raw = re.sub(r"\n{3,}", "\n\n", raw)
+        return raw.strip()
+
+    def _ensure_newline(self) -> None:
+        if self._parts and not self._parts[-1].endswith("\n"):
+            self._parts.append("\n")
+        self._pending_space = False
+
+
+def convert_book(input_path: str, output_dir: str) -> List[str]:
+    """Convert a book at *input_path* into plain text chapters.
+
+    Only EPUB files are currently supported.  The function returns a list of
+    the generated file paths relative to *output_dir*.
+    """
+
+    input_path = os.path.abspath(input_path)
+    if not os.path.exists(input_path):
+        raise FileNotFoundError(f"Book not found: {input_path}")
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    ext = os.path.splitext(input_path)[1].lower()
+    if ext == ".epub":
+        return list(_write_chapters(convert_epub_to_text(input_path), output_dir))
+
+    raise ValueError(f"Unsupported book format: {ext or 'unknown'}")
+
+
+def convert_epub_to_text(epub_path: str) -> Iterator[Chapter]:
+    """Yield :class:`Chapter` instances extracted from *epub_path*."""
+
+    with zipfile.ZipFile(epub_path, "r") as archive:
+        container_info = _read_container_file(archive)
+        opf_path = container_info["full-path"]
+        opf_dir = posixpath.dirname(opf_path)
+
+        manifest, spine = _read_package_document(archive, opf_path)
+
+        for index, item_id in enumerate(spine, start=1):
+            href = manifest.get(item_id)
+            if href is None:
+                continue
+            chapter_path = posixpath.normpath(posixpath.join(opf_dir, href))
+            try:
+                with archive.open(chapter_path) as chapter_file:
+                    html_bytes = chapter_file.read()
+            except KeyError:
+                continue
+
+            text, title = _extract_text_from_html(html_bytes)
+            yield Chapter(index=index, title=title or f"Chapter {index}", text=text)
+
+
+def _read_container_file(archive: zipfile.ZipFile) -> dict[str, str]:
+    try:
+        with archive.open("META-INF/container.xml") as container:
+            tree = ET.parse(container)
+    except KeyError as exc:  # pragma: no cover - invalid EPUBs are rare in tests
+        raise ValueError("Invalid EPUB: container.xml missing") from exc
+
+    root = tree.getroot()
+    element = root.find("container:rootfiles/container:rootfile", OPF_NS)
+    if element is None or "full-path" not in element.attrib:
+        raise ValueError("Invalid EPUB: unable to locate OPF package")
+    return element.attrib
+
+
+def _read_package_document(
+    archive: zipfile.ZipFile, opf_path: str
+) -> tuple[dict[str, str], List[str]]:
+    try:
+        with archive.open(opf_path) as opf_file:
+            tree = ET.parse(opf_file)
+    except KeyError as exc:  # pragma: no cover - invalid EPUBs are rare in tests
+        raise ValueError(f"Invalid EPUB: package file {opf_path!r} missing") from exc
+
+    root = tree.getroot()
+    manifest: dict[str, str] = {}
+    for item in root.findall("opf:manifest/opf:item", OPF_NS):
+        item_id = item.attrib.get("id")
+        href = item.attrib.get("href")
+        if item_id and href:
+            manifest[item_id] = href
+
+    spine: List[str] = []
+    for itemref in root.findall("opf:spine/opf:itemref", OPF_NS):
+        item_idref = itemref.attrib.get("idref")
+        if item_idref:
+            spine.append(item_idref)
+
+    return manifest, spine
+
+
+def _extract_text_from_html(html_bytes: bytes) -> tuple[str, Optional[str]]:
+    # Try UTF-8 first and fallback to latin-1 which is permissive while still
+    # yielding readable results for most encodings.
+    for encoding in ("utf-8", "utf-16", "latin-1"):
+        try:
+            html_text = html_bytes.decode(encoding)
+            break
+        except UnicodeDecodeError:
+            continue
+    else:  # pragma: no cover - unexpected encoding
+        html_text = html_bytes.decode("utf-8", errors="ignore")
+
+    parser = _HTMLToTextParser()
+    parser.feed(html_text)
+    parser.close()
+    return parser.get_text(), parser.title
+
+
+def _write_chapters(chapters: Iterable[Chapter], output_dir: str) -> Iterator[str]:
+    for chapter in chapters:
+        filename = _chapter_filename(chapter.index, chapter.title)
+        path = os.path.join(output_dir, filename)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(chapter.text + "\n")
+        yield path
+
+
+def _chapter_filename(index: int, title: str) -> str:
+    slug = _slugify(title)
+    return f"chapter_{index:03d}_{slug}.txt"
+
+
+def _slugify(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
+    ascii_text = ascii_text.lower()
+    ascii_text = re.sub(r"[^a-z0-9]+", "-", ascii_text).strip("-")
+    return ascii_text or "chapter"

--- a/scripts/convert_book.py
+++ b/scripts/convert_book.py
@@ -1,0 +1,66 @@
+"""Command line interface for the book conversion helpers."""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Iterable
+
+from book_tools.converter import convert_book
+
+
+def _find_candidate_books(paths: Iterable[Path]) -> list[Path]:
+    candidates: list[Path] = []
+    for path in paths:
+        if not path.exists():
+            continue
+        if path.is_file():
+            candidates.append(path)
+            continue
+        for extension in ("*.epub",):
+            candidates.extend(path.rglob(extension))
+    return sorted({candidate.resolve() for candidate in candidates})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Convert ebooks into chapter text files.")
+    parser.add_argument(
+        "input",
+        nargs="?",
+        help="Path to the ebook. If omitted the script looks for EPUB files under ./book or ./data.",
+    )
+    parser.add_argument(
+        "--output",
+        default="converted_chapters",
+        help="Directory that will receive the generated chapter text files (default: converted_chapters).",
+    )
+    args = parser.parse_args()
+
+    if args.input:
+        book_path = Path(args.input).expanduser()
+        candidates = [book_path]
+    else:
+        search_roots = [Path("book"), Path("data"), Path(".")]
+        candidates = _find_candidate_books(search_roots)
+        if not candidates:
+            parser.error("No EPUB files were found. Provide the path explicitly or place the book under ./book or ./data.")
+        if len(candidates) > 1:
+            parser.error(
+                "Multiple EPUB files found. Please specify the desired file explicitly.\n" +
+                "\n".join(str(candidate) for candidate in candidates)
+            )
+        book_path = candidates[0]
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    created = convert_book(str(book_path), str(output_dir))
+    rel_paths = [os.path.relpath(path, os.getcwd()) for path in created]
+    for rel in rel_paths:
+        print(rel)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution entrypoint
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the project root is on sys.path when tests are executed via pytest from
+# an arbitrary working directory (which mirrors the behaviour of python -m).
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+from book_tools.converter import convert_epub_to_text, convert_book
+
+
+def _create_epub(path: Path) -> None:
+    # Build a very small EPUB file with two chapters.
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("mimetype", "application/epub+zip")
+        zf.writestr(
+            "META-INF/container.xml",
+            """<?xml version='1.0' encoding='utf-8'?>
+            <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+              <rootfiles>
+                <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+              </rootfiles>
+            </container>
+            """,
+        )
+        zf.writestr(
+            "OEBPS/content.opf",
+            """<?xml version='1.0' encoding='utf-8'?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="BookId">
+              <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                <dc:title>Sample Book</dc:title>
+              </metadata>
+              <manifest>
+                <item id="chap1" href="chapter1.xhtml" media-type="application/xhtml+xml" />
+                <item id="chap2" href="chapters/chapter2.xhtml" media-type="application/xhtml+xml" />
+              </manifest>
+              <spine>
+                <itemref idref="chap1" />
+                <itemref idref="chap2" />
+              </spine>
+            </package>
+            """,
+        )
+        zf.writestr(
+            "OEBPS/chapter1.xhtml",
+            """<?xml version='1.0' encoding='utf-8'?>
+            <html xmlns="http://www.w3.org/1999/xhtml">
+              <head><title>Chapter One</title></head>
+              <body>
+                <h1>Chapter One</h1>
+                <p>Once upon a time in a land far away.</p>
+                <p>There lived a developer.</p>
+              </body>
+            </html>
+            """,
+        )
+        zf.writestr(
+            "OEBPS/chapters/chapter2.xhtml",
+            """<?xml version='1.0' encoding='utf-8'?>
+            <html xmlns="http://www.w3.org/1999/xhtml">
+              <body>
+                <h1>Another Chapter</h1>
+                <p>More content follows with <strong>formatting</strong>.</p>
+              </body>
+            </html>
+            """,
+        )
+
+
+def test_convert_epub_to_text(tmp_path: Path) -> None:
+    epub_path = tmp_path / "book.epub"
+    _create_epub(epub_path)
+
+    chapters = list(convert_epub_to_text(str(epub_path)))
+    assert [chapter.title for chapter in chapters] == ["Chapter One", "Another Chapter"]
+    assert chapters[0].text.startswith("Chapter One")
+    assert "More content follows" in chapters[1].text
+
+
+def test_convert_book_writes_files(tmp_path: Path) -> None:
+    epub_path = tmp_path / "book.epub"
+    _create_epub(epub_path)
+
+    output_dir = tmp_path / "out"
+    written_files = convert_book(str(epub_path), str(output_dir))
+
+    assert len(written_files) == 2
+    contents = [Path(path).read_text(encoding="utf-8") for path in written_files]
+    assert "developer" in contents[0]
+    assert contents[1].strip().endswith("formatting.")


### PR DESCRIPTION
## Summary
- add a reusable `book_tools` module that converts EPUB chapters into cleaned plain text
- expose the functionality via a `scripts/convert_book.py` CLI and document usage in the README
- cover the workflow with pytest-based regression tests that build a sample EPUB on the fly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8e100d3a083209e322336b341f281